### PR TITLE
shrink canvas to 600px, then 500px on smaller screens

### DIFF
--- a/css/codemirror_editors.css
+++ b/css/codemirror_editors.css
@@ -31,13 +31,6 @@
     cursor: pointer;
 }
 
-.preview_container {
-    min-width: 650px;
-    min-height: 550px;
-    position: relative;
-    /*border: 2px solid red;*/
-}
-
 #p5_canvas{
     margin-top: 200px;
 }

--- a/css/codemirror_editors.css
+++ b/css/codemirror_editors.css
@@ -10,7 +10,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    min-height: 85vh;
+    min-height: 75vh;
 }
 
 #js_editor.show-js-hints .js-hint:not(.js-read-only) {

--- a/css/styles.css
+++ b/css/styles.css
@@ -119,6 +119,7 @@ main > .row.border-bottom{
 .preview_container {
   display: flex;
   justify-content: center;
-  min-width: 640px;
+  min-width: 500px;
   height: 100%;
+  position: relative;
 }

--- a/mini/index.html
+++ b/mini/index.html
@@ -62,6 +62,13 @@
 
         @media screen and (max-width: 640px) {
             #p5_canvas canvas {
+                width: 600px !important;
+                height: 450px !important;
+            }
+        }
+
+        @media screen and (max-width: 600px) {
+            #p5_canvas canvas {
                 width: 500px !important;
                 height: 375px !important;
             }

--- a/mini/index.html
+++ b/mini/index.html
@@ -60,6 +60,13 @@
             justify-content: center;
         }
 
+        @media screen and (max-width: 640px) {
+            #p5_canvas canvas {
+                width: 500px !important;
+                height: 375px !important;
+            }
+        }
+
         .controls{
             display: flex;
             justify-content: center;


### PR DESCRIPTION
This shrinks the canvas of the game to 500px if the width of the game's "window" (i.e. pane in the editor) is under 640px, so that it can be displayed side-by-side with the code on chromebooks and other devices that have smaller screens.
