### PR TITLE
auto-advance to next level 8 seconds after winning

### DIFF
--- a/mini/game.js
+++ b/mini/game.js
@@ -11,7 +11,7 @@ var CURRENT_LEVEL_TEXT = "TODO: Set CURRENT_LEVEL_TEXT for this level!";
 
 var UNLOCK_GRID_LEVEL = 1;
 
-var player, particles, platforms, goalReached;
+var player, particles, platforms, goalReached, autoAdvanceToNextLevel;
 
 function setup() {
     var myCanvas = createCanvas(WIDTH, HEIGHT);
@@ -28,6 +28,8 @@ function setup() {
 
     player = createSprite(PLAYER_START_X, PLAYER_START_Y, 20, 20);
     player.shapeColor = 'Aqua';
+
+    autoAdvanceToNextLevel = 0;
 
     base_setupLevel();
     setupLevel();
@@ -97,9 +99,15 @@ function draw() {
         rectMode(CORNER);
     }
 
-    if (player.overlap(goal)) {
+    if (player.overlap(goal) && !goalReached) {
         showNextLevelButton();
         goalReached = true;
+        autoAdvanceToNextLevel = frameCount + (frameRate() * 8);
+    }
+
+    if (autoAdvanceToNextLevel && frameCount >= autoAdvanceToNextLevel) {
+        autoAdvanceToNextLevel = 0;
+        nextLevel();
     }
 
     drawDialogue();


### PR DESCRIPTION
This is an alternative to #45... instead of showing a tooltip under "next level", we just automatically advance the player to the next level after they win the current one.

Not sure if this deals appropriately with the very last level, though, since there's no next level to go to...
